### PR TITLE
missing psql in __main__.py

### DIFF
--- a/pglite/__main__.py
+++ b/pglite/__main__.py
@@ -1,4 +1,4 @@
-from .pglite import check_cluster, init_cluster, reset_cluster, start_cluster, stop_cluster, cluster_params, is_started, create_db, drop_db, list_db, export_db, import_db, die
+from .pglite import check_cluster, init_cluster, reset_cluster, start_cluster, stop_cluster, cluster_params, is_started, create_db, drop_db, list_db, export_db, import_db, die, psql
 import sys
 
 usage = """


### PR DESCRIPTION
pglite psql returned:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.6/site-packages/pglite/__main__.py", line 81, in <module>
    psql(sys.argv[2:])
NameError: name 'psql' is not defined
```