### PR TITLE
Change bash to sh in pglite script

### DIFF
--- a/script/pglite
+++ b/script/pglite
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 python -m pglite $@


### PR DESCRIPTION
 $@ is not specific to bash and all classical bourne shell (sh) or derived (bash, ksh, zsh, etc.) can interpret it. Moreover, /bin/bash can not exists on some platforms.