### PR TITLE
Search for pg_ctl in $PATH

### DIFF
--- a/pglite/pglite.py
+++ b/pglite/pglite.py
@@ -66,6 +66,7 @@ def find_pg_ctl():
                  '/usr/lib/postgresql/9.5/bin/pg_ctl',
                  '/usr/lib/postgresql/9.4/bin/pg_ctl',
                  '/usr/lib/postgresql/9.3/bin/pg_ctl']
+        paths += [os.path.join(path, 'pg_ctl') for path in os.environ['PATH'].split(':')]
     elif sys.platform.startswith('freebsd'):
         paths = [sys.exec_prefix+'/bin/pg_ctl']
     else: # Windows


### PR DESCRIPTION
On Fedora by default pg_ctl sits in `/usr/bin`